### PR TITLE
fix: fix all compiler warnings

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -93,7 +93,7 @@ jobs:
 
       - name: format diff
         run: |
-          moon fmt --block-style
+          moon fmt
           git diff --exit-code
 
       - name: Setup MSVC

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The simplest way to use `dotenv-mbt` is with the `EnvLoader`:
 ```moonbit
 fn main {
   let env_map = @dotenv.EnvLoader::new?().unwrap().load?().unwrap()
-  let host = env_map.var?("HOST").unwrap()
+  let host = env_map.get("HOST").unwrap()
   println("HOST=\{host}")
 }
 ```
@@ -74,19 +74,22 @@ let loader2 = @dotenv.EnvLoader::new?().unwrap()
 
 ### **🔄 Variable Access**
 
-After loading the environment, you can access variables using the `var` method:
+After loading the environment, you can access variables using the `get` method:
 
 ```moonbit
 let env_map = @dotenv.EnvLoader::new?().unwrap().load?().unwrap()
 
-// Get a variable (returns Result)
-let host = env_map.var?("HOST").unwrap()
+// Get a variable (returns Option)
+let host = env_map.get("HOST").unwrap()
 
 // Get with default value if not found
-let port = env_map.var?("PORT").or("8080")
+let port = match env_map.get("PORT") {
+  Some(p) => p
+  None => "8080"
+}
 
 // Check if a variable exists
-if env_map.var?("DATABASE_URL").is_ok() {
+if env_map.get("DATABASE_URL").is_some() {
   // Do something with database URL
 }
 ```
@@ -133,14 +136,17 @@ fn main {
   let env = @dotenv.EnvLoader::new?().unwrap().load?().unwrap()
 
   // Access variables
-  let host = env.var?("HOST").unwrap()
-  let port = env.var?("PORT").or("8080") // Default to 8080 if not set
+  let host = env.get("HOST").unwrap()
+  let port = match env.get("PORT") {
+    Some(p) => p
+    None => "8080"  // Default to 8080 if not set
+  }
 
   // Use variables in your application
   println("Server running at \{host}:\{port}")
 
   // Check if a variable exists
-  if env.var?("DEBUG").is_ok() {
+  if env.get("DEBUG").is_some() {
     println("Debug mode enabled")
   }
 }

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -2,7 +2,7 @@
   "name": "ShellWen/dotenv",
   "version": "0.4.0",
   "deps": {
-    "moonbitlang/x": "0.4.25"
+    "moonbitlang/x": "0.4.32"
   },
   "readme": "README.md",
   "repository": "https://github.com/moonbit-community/dotenv-mbt.git",

--- a/src/cursor.mbt
+++ b/src/cursor.mbt
@@ -35,7 +35,7 @@ fn Cursor::read_line(self : Cursor) -> String {
       result.write_char('\n')
       break
     }
-    result.write_char(Char::from_int(byte))
+    result.write_char(byte.unsafe_to_char())
   }
   // Convert the result to a string
   result.to_string()
@@ -51,7 +51,7 @@ fn Cursor::next(self : Cursor) -> Int? {
   if self.pos >= self.data.length().to_uint64() {
     None
   } else {
-    let char = self.data.charcode_at(self.pos.to_int())
+    let char = self.data[self.pos.to_int()]
     self.pos += 1
     Some(char)
   }
@@ -62,7 +62,7 @@ fn Cursor::peek(self : Cursor) -> Int? {
   if self.pos >= self.data.length().to_uint64() {
     None
   } else {
-    Some(self.data.charcode_at(self.pos.to_int()))
+    Some(self.data[self.pos.to_int()])
   }
 }
 

--- a/src/dotenv.mbti
+++ b/src/dotenv.mbti
@@ -1,37 +1,39 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "ShellWen/dotenv"
 
 // Values
-fn load(path~ : String = .., ignore_file_not_found~ : Bool = ..) -> EnvMap!DotenvError
+fn load(path? : String, ignore_file_not_found? : Bool) -> EnvMap raise DotenvError
 
-fn load_and_modify(path~ : String = .., ignore_file_not_found~ : Bool = ..) -> EnvMap!DotenvError
+fn load_and_modify(path? : String, ignore_file_not_found? : Bool) -> EnvMap raise DotenvError
 
-fn temp_env[R, E : Error](Map[String, String], () -> R!E) -> R!E
+fn[R, E : Error] temp_env(Map[String, String], () -> R raise E) -> R raise E
 
-// Types and methods
-pub type! DotenvError {
+// Errors
+pub suberror DotenvError {
   FileNotFound(String)
   LineParseError(String, UInt)
   Io(Error, String)
   InvalidOp
 }
 
+pub suberror ParseBufError {
+  LineParse(String, UInt)
+}
+
+// Types and methods
 pub struct EnvLoader {
   mut path : String?
   // private fields
 }
-impl EnvLoader {
-  from_path(String) -> Self!DotenvError
-  from_string(String) -> Self
-  load(Self) -> EnvMap!DotenvError
-  load_and_modify(Self) -> EnvMap!DotenvError
-  set_path(Self, String?) -> Self
-  set_sequence(Self, EnvSequence) -> Self
-}
+fn EnvLoader::from_path(String) -> Self raise DotenvError
+fn EnvLoader::from_string(String) -> Self
+fn EnvLoader::load(Self) -> EnvMap raise DotenvError
+fn EnvLoader::load_and_modify(Self) -> EnvMap raise DotenvError
+fn EnvLoader::set_path(Self, String?) -> Self
+fn EnvLoader::set_sequence(Self, EnvSequence) -> Self
 
 type EnvMap
-impl EnvMap {
-  var(Self, String) -> String?
-}
+fn EnvMap::get(Self, String) -> String?
 
 pub(all) enum EnvSequence {
   EnvOnly
@@ -40,10 +42,6 @@ pub(all) enum EnvSequence {
   InputThenEnv
 }
 impl Default for EnvSequence
-
-pub type! ParseBufError {
-  LineParse(String, UInt)
-}
 
 // Type aliases
 

--- a/src/error.mbt
+++ b/src/error.mbt
@@ -1,5 +1,5 @@
 ///|
-pub type! DotenvError {
+pub suberror DotenvError {
   /// When the file is not found.
   FileNotFound(String)
   LineParseError(String, UInt)

--- a/src/iter.mbt
+++ b/src/iter.mbt
@@ -13,8 +13,8 @@ fn DotenvIter::new(data : String) -> DotenvIter {
 ///|
 fn DotenvIter::internal_load(
   self : DotenvIter,
-  load_fn : (String, String, EnvMap) -> Unit
-) -> EnvMap!ParseBufError {
+  load_fn : (String, String, EnvMap) -> Unit,
+) -> EnvMap raise ParseBufError {
   self.remove_bom()
   let map = EnvMap::new()
   for {
@@ -22,7 +22,7 @@ fn DotenvIter::internal_load(
     if item.is_empty() {
       break
     }
-    let item = item.unwrap().unwrap_or_error!()
+    let item = item.unwrap().unwrap_or_error()
     let (k, v) = item
     load_fn(k, v, map)
   }
@@ -30,15 +30,15 @@ fn DotenvIter::internal_load(
 }
 
 ///|
-fn DotenvIter::load(self : DotenvIter) -> EnvMap!ParseBufError {
-  self.internal_load!(fn(k, v, map) { map.map[k] = v })
+fn DotenvIter::load(self : DotenvIter) -> EnvMap raise ParseBufError {
+  self.internal_load(fn(k, v, map) { map.map[k] = v })
 }
 
 ///|
-fn DotenvIter::load_and_modify(self : DotenvIter) -> EnvMap!ParseBufError {
+fn DotenvIter::load_and_modify(self : DotenvIter) -> EnvMap raise ParseBufError {
   // Not thread-safe
   let vars = @sys.get_env_vars()
-  self.internal_load!(fn(k, v, map) {
+  self.internal_load(fn(k, v, map) {
     if not(vars.contains(k)) {
       @sys.set_env_var(k, v)
     }
@@ -48,9 +48,9 @@ fn DotenvIter::load_and_modify(self : DotenvIter) -> EnvMap!ParseBufError {
 
 ///|
 fn DotenvIter::load_and_modify_override(
-  self : DotenvIter
-) -> EnvMap!ParseBufError {
-  self.internal_load!(fn(k, v, map) {
+  self : DotenvIter,
+) -> EnvMap raise ParseBufError {
+  self.internal_load(fn(k, v, map) {
     @sys.set_env_var(k, v)
     map.map[k] = v
   })
@@ -62,17 +62,12 @@ fn DotenvIter::load_and_modify_override(
 fn DotenvIter::remove_bom(self : DotenvIter) -> Unit {
   guard self.cursor.length() >= 3 else { return }
   let origin_pos = self.cursor.pos()
-  let bom : FixedArray[Byte] = [0xEF, 0xBB, 0xBF]
-  let start : FixedArray[Byte] = FixedArray::makei(3, fn(_) -> Byte {
-    self.cursor.next().or(0).to_byte()
-  })
-  if start == bom {
-    // The BOM is present, so we skip it
-    self.cursor.set_pos(origin_pos + 3)
-  } else {
-    // The BOM is not present, so we reset the cursor position
-    self.cursor.set_pos(origin_pos)
+  if self.cursor.next() is Some(0xfeff) {
+    // The BOM is present, so exit early
+    return
   }
+  // The BOM is not present, so we reset the cursor position
+  self.cursor.set_pos(origin_pos)
 }
 
 ///|
@@ -85,7 +80,7 @@ priv enum ParseState {
   WeakOpenEscape
   Comment
   WhiteSpace
-} derive(Eq, Show)
+} derive(Eq)
 
 ///|
 fn ParseState::eval_end(self : ParseState, buf : String) -> (UInt, ParseState) {
@@ -135,7 +130,7 @@ fn ParseState::eval_end(self : ParseState, buf : String) -> (UInt, ParseState) {
 
 ///|
 fn DotenvIter::next(
-  self : DotenvIter
+  self : DotenvIter,
 ) -> Result[(String, String), ParseBufError]? {
   for {
     let line = match self.cursor.next_line() {
@@ -143,7 +138,7 @@ fn DotenvIter::next(
       Some(Err(e)) => return Some(Err(e))
       None => return None
     }
-    match parse_line?(line, self.substitution_data) {
+    match (try? parse_line(line, self.substitution_data)) {
       Ok(Some(res)) => return Some(Ok(res))
       Ok(None) => continue
       Err(e) => return Some(Err(e))
@@ -152,6 +147,6 @@ fn DotenvIter::next(
 }
 
 ///|
-pub type! ParseBufError {
+pub suberror ParseBufError {
   LineParse(String, UInt)
 }

--- a/src/iter_wbtest.mbt
+++ b/src/iter_wbtest.mbt
@@ -1,10 +1,10 @@
 ///|
 test "remove bom" {
   // BOM present
-  let b = "\xEF\xBB\xBFkey=value\n"
+  let b = "\u{FEFF}key=value\n"
   let iter = DotenvIter::new(b)
   iter.remove_bom()
-  assert_eq!(iter.cursor.read_line(), "key=value\n")
+  assert_eq(iter.cursor.read_line(), "key=value\n")
 }
 
 ///|
@@ -13,5 +13,5 @@ test "remove bom no bom" {
   let b = "key=value\n"
   let iter = DotenvIter::new(b)
   iter.remove_bom()
-  assert_eq!(iter.cursor.read_line(), "key=value\n")
+  assert_eq(iter.cursor.read_line(), "key=value\n")
 }

--- a/src/lib.mbt
+++ b/src/lib.mbt
@@ -10,7 +10,7 @@ fn EnvMap::new() -> EnvMap {
 }
 
 ///|
-pub fn EnvMap::var(self : EnvMap, name : String) -> String? {
+pub fn EnvMap::get(self : EnvMap, name : String) -> String? {
   self.map.get(name)
 }
 
@@ -39,10 +39,10 @@ pub struct EnvLoader {
 }
 
 ///|
-pub fn EnvLoader::from_path(path : String) -> EnvLoader!DotenvError {
-  let str = @fs.read_file_to_string?(path)
+pub fn EnvLoader::from_path(path : String) -> EnvLoader raise DotenvError {
+  let str = (try? @fs.read_file_to_string(path))
     .map_err(fn(e) { DotenvError::Io(e, path) })
-    .unwrap_or_error!()
+    .unwrap_or_error()
   { path: Some(path), str, sequence: EnvSequence::default() }
 }
 
@@ -64,54 +64,55 @@ pub fn EnvLoader::set_path(self : EnvLoader, path : String?) -> EnvLoader {
 ///| Sets the sequence in which to load environment variables.
 pub fn EnvLoader::set_sequence(
   self : EnvLoader,
-  sequence : EnvSequence
+  sequence : EnvSequence,
 ) -> EnvLoader {
   self.sequence = sequence
   self
 }
 
 ///|
-fn EnvLoader::load_input(self : EnvLoader) -> EnvMap!DotenvError {
+fn EnvLoader::load_input(self : EnvLoader) -> EnvMap raise DotenvError {
   let iter = DotenvIter::new(self.str)
-  iter
-  .load?()
-  .map_err(fn(e) {
-    match e {
-      ParseBufError::LineParse(line, pos) =>
-        DotenvError::LineParseError(line, pos)
-    }
-  })
-  .unwrap_or_error!()
+  let result = try? iter.load()
+  match result {
+    Ok(env_map) => env_map
+    Err(e) =>
+      match e {
+        ParseBufError::LineParse(line, pos) =>
+          raise DotenvError::LineParseError(line, pos)
+      }
+  }
 }
 
 ///|
-fn EnvLoader::load_input_and_modify(self : EnvLoader) -> EnvMap!DotenvError {
+fn EnvLoader::load_input_and_modify(
+  self : EnvLoader,
+) -> EnvMap raise DotenvError {
   let iter = DotenvIter::new(self.str)
-  iter
-  .load_and_modify?()
+  (try? iter.load_and_modify())
   .map_err(fn(e) {
     match e {
       ParseBufError::LineParse(line, pos) =>
         DotenvError::LineParseError(line, pos)
     }
   })
-  .unwrap_or_error!()
+  .unwrap_or_error()
 }
 
 ///|
 fn EnvLoader::load_input_and_modify_override(
-  self : EnvLoader
-) -> EnvMap!DotenvError {
+  self : EnvLoader,
+) -> EnvMap raise DotenvError {
   let iter = DotenvIter::new(self.str)
-  iter
-  .load_and_modify_override?()
+  let result = try? iter.load_and_modify_override()
+  result
   .map_err(fn(e) {
     match e {
       ParseBufError::LineParse(line, pos) =>
         DotenvError::LineParseError(line, pos)
     }
   })
-  .unwrap_or_error!()
+  .unwrap_or_error()
 }
 
 ///|
@@ -123,18 +124,18 @@ fn env_vars() -> @hashmap.T[String, String] {
 ///| Loads environment variables into a hash map.
 ///
 /// This is the primary method for loading environment variables.
-pub fn EnvLoader::load(self : EnvLoader) -> EnvMap!DotenvError {
+pub fn EnvLoader::load(self : EnvLoader) -> EnvMap raise DotenvError {
   match self.sequence {
     EnvOnly => { map: env_vars() }
     EnvThenInput => {
       let existing = env_vars()
-      let input = self.load_input!()
+      let input = self.load_input()
       input.map.each(fn(k, v) { existing.set(k, v) })
       { map: existing }
     }
-    InputOnly => self.load_input!()
+    InputOnly => self.load_input()
     InputThenEnv => {
-      let input = self.load_input!()
+      let input = self.load_input()
       let existing = env_vars()
       existing.each(fn(k, v) { input.map.set(k, v) })
       input
@@ -145,12 +146,12 @@ pub fn EnvLoader::load(self : EnvLoader) -> EnvMap!DotenvError {
 ///| Shortcut for loading environment variables from a file.
 pub fn load(
   path~ : String = "./.env",
-  ignore_file_not_found~ : Bool = true
-) -> EnvMap!DotenvError {
-  if @fs.path_exists(path) && @fs.is_file?(path).or(false) {
-    EnvLoader::from_path!(path).load!()
+  ignore_file_not_found~ : Bool = true,
+) -> EnvMap raise DotenvError {
+  if @fs.path_exists(path) && (try? @fs.is_file(path)).or(false) {
+    EnvLoader::from_path(path).load()
   } else if ignore_file_not_found {
-    EnvLoader::from_string("").set_sequence(EnvSequence::EnvOnly).load!()
+    EnvLoader::from_string("").set_sequence(EnvSequence::EnvOnly).load()
   } else {
     raise DotenvError::FileNotFound(path)
   }
@@ -159,19 +160,19 @@ pub fn load(
 ///| Loads environment variables into a hash map, modifying the existing environment.
 ///
 /// This calls `@sys.set_env_var` internally.
-pub fn EnvLoader::load_and_modify(self : EnvLoader) -> EnvMap!DotenvError {
+pub fn EnvLoader::load_and_modify(self : EnvLoader) -> EnvMap raise DotenvError {
   match self.sequence {
     InputOnly => raise DotenvError::InvalidOp
     EnvThenInput => {
       let existing = env_vars()
-      let input = self.load_input_and_modify_override!()
+      let input = self.load_input_and_modify_override()
       input.map.each(fn(k, v) { existing.set(k, v) })
       { map: existing }
     }
-    EnvOnly => self.load_input_and_modify_override!()
+    EnvOnly => self.load_input_and_modify_override()
     InputThenEnv => {
       let existing = env_vars()
-      let input = self.load_input_and_modify!()
+      let input = self.load_input_and_modify()
       input.map.each(fn(k, v) {
         if not(existing.contains(k)) {
           @sys.set_env_var(k, v)
@@ -186,13 +187,13 @@ pub fn EnvLoader::load_and_modify(self : EnvLoader) -> EnvMap!DotenvError {
 ///| Shortcut for loading environment variables from a file and modifying the existing environment.
 pub fn load_and_modify(
   path~ : String = "./.env",
-  ignore_file_not_found~ : Bool = true
-) -> EnvMap!DotenvError {
-  if @fs.path_exists(path) && @fs.is_file?(path).or(false) {
-    EnvLoader::from_path!(path).load_and_modify!()
+  ignore_file_not_found~ : Bool = true,
+) -> EnvMap raise DotenvError {
+  if @fs.path_exists(path) && (try? @fs.is_file(path)).or(false) {
+    EnvLoader::from_path(path).load_and_modify()
   } else if ignore_file_not_found {
     // If the file is not found, we do the same as in `load`.
-    EnvLoader::from_string("").set_sequence(EnvSequence::EnvOnly).load!()
+    EnvLoader::from_string("").set_sequence(EnvSequence::EnvOnly).load()
   } else {
     raise DotenvError::FileNotFound(path)
   }

--- a/src/lib_test.mbt
+++ b/src/lib_test.mbt
@@ -6,29 +6,30 @@ test "substitution" {
     "$ZZZ", "$KEY", "$KEY1", "${KEY}1", "$KEY_U", "${KEY_U}", "\\$KEY",
   ]
   let common_string = subs.join(">>")
-  let s = #|    KEY1=new_value1
-  #|    KEY_U=$KEY+valueU
-  #|    
-  #|    STRONG_QUOTES='{common_string}'
-  #|    WEAK_QUOTES="{common_string}"
-  #|    NO_QUOTES={common_string}
-  #|    
-  .replace_all(old="{common_string}", new=common_string)
+  let s = (
+    #|    KEY1=new_value1
+    #|    KEY_U=$KEY+valueU
+    #|    
+    #|    STRONG_QUOTES='{common_string}'
+    #|    WEAK_QUOTES="{common_string}"
+    #|    NO_QUOTES={common_string}
+    #|    
+  ).replace_all(old="{common_string}", new=common_string)
   let env_map = EnvLoader::from_string(s)
     .set_sequence(EnvSequence::InputThenEnv)
-    .load!()
-  assert_eq!(env_map.var("KEY").unwrap(), "value")
-  assert_eq!(env_map.var("KEY1").unwrap(), "value1")
-  assert_eq!(env_map.var("KEY_U").unwrap(), "value+valueU")
-  assert_eq!(env_map.var("STRONG_QUOTES").unwrap(), common_string)
-  assert_eq!(
-    env_map.var("WEAK_QUOTES").unwrap(),
+    .load()
+  assert_eq(env_map.get("KEY").unwrap(), "value")
+  assert_eq(env_map.get("KEY1").unwrap(), "value1")
+  assert_eq(env_map.get("KEY_U").unwrap(), "value+valueU")
+  assert_eq(env_map.get("STRONG_QUOTES").unwrap(), common_string)
+  assert_eq(
+    env_map.get("WEAK_QUOTES").unwrap(),
     ["", "value", "value1", "value1", "value_U", "value+valueU", "$KEY"].join(
       ">>",
     ),
   )
-  assert_eq!(
-    env_map.var("NO_QUOTES").unwrap(),
+  assert_eq(
+    env_map.get("NO_QUOTES").unwrap(),
     ["", "value", "value1", "value1", "value_U", "value+valueU", "$KEY"].join(
       ">>",
     ),
@@ -39,31 +40,33 @@ test "substitution" {
 test "multiline" {
   let value = "-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\\n\\\"QUOTED\\\""
   let weak = "-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n\"QUOTED\""
-  let s = #|    KEY=my\ cool\ value
-  #|    KEY3="awesome \"stuff\"
-  #|    more
-  #|    on other
-  #|    lines"
-  #|    KEY4='hello '\''world'"
-  #|    good ' \'morning"
-  #|    WEAK="{value}"
-  #|    STRONG='{value}'
-  .replace_all(old="{value}", new=value)
-  let env_map = EnvLoader::from_string(s)
-    .set_sequence(EnvSequence::InputOnly)
-    .load!()
-  assert_eq!(env_map.var("KEY").unwrap(), "my cool value")
-  assert_eq!(
-    env_map.var("KEY3").unwrap(),
-    #|awesome "stuff"
+  let s = (
+    #|    KEY=my\ cool\ value
+    #|    KEY3="awesome \"stuff\"
     #|    more
     #|    on other
-    #|    lines
-    ,
+    #|    lines"
+    #|    KEY4='hello '\''world'"
+    #|    good ' \'morning"
+    #|    WEAK="{value}"
+    #|    STRONG='{value}'
+  ).replace_all(old="{value}", new=value)
+  let env_map = EnvLoader::from_string(s)
+    .set_sequence(EnvSequence::InputOnly)
+    .load()
+  assert_eq(env_map.get("KEY").unwrap(), "my cool value")
+  assert_eq(
+    env_map.get("KEY3").unwrap(),
+    (
+      #|awesome "stuff"
+      #|    more
+      #|    on other
+      #|    lines
+    ),
   )
-  assert_eq!(env_map.var("KEY4").unwrap(), "hello 'world\n    good ' 'morning")
-  assert_eq!(env_map.var("WEAK").unwrap(), weak)
-  assert_eq!(env_map.var("STRONG").unwrap(), value)
+  assert_eq(env_map.get("KEY4").unwrap(), "hello 'world\n    good ' 'morning")
+  assert_eq(env_map.get("WEAK").unwrap(), weak)
+  assert_eq(env_map.get("STRONG").unwrap(), value)
 }
 
 ///|
@@ -88,48 +91,48 @@ test "multiline comment" {
     #|
   let env_map = EnvLoader::from_string(s)
     .set_sequence(EnvSequence::InputOnly)
-    .load!()
-  assert_eq!(env_map.var("TESTKEY1").unwrap(), "test_val")
-  assert_eq!(env_map.var("TESTKEY2").unwrap(), "test_val_with_#_hash")
-  assert_eq!(env_map.var("TESTKEY3").unwrap(), "test_val quoted with # hash")
-  assert_eq!(env_map.var("TESTKEY4").unwrap(), "Line 1\n# Line 2\nLine 3")
-  assert_eq!(env_map.var("TESTKEY5").unwrap(), "Line 4\n# Line 5\nLine 6\n")
+    .load()
+  assert_eq(env_map.get("TESTKEY1").unwrap(), "test_val")
+  assert_eq(env_map.get("TESTKEY2").unwrap(), "test_val_with_#_hash")
+  assert_eq(env_map.get("TESTKEY3").unwrap(), "test_val quoted with # hash")
+  assert_eq(env_map.get("TESTKEY4").unwrap(), "Line 1\n# Line 2\nLine 3")
+  assert_eq(env_map.get("TESTKEY5").unwrap(), "Line 4\n# Line 5\nLine 6\n")
 }
 
 ///|
 test "non modify" {
-  temp_env!({ "SRC": "env" }, fn() -> Unit!Error {
+  temp_env({ "SRC": "env" }, fn() -> Unit raise Error {
     let s = "SRC=envfile\nFOO=bar"
     let env_map = EnvLoader::from_string(s)
       .set_sequence(EnvSequence::EnvThenInput)
-      .load!()
-    assert_eq!(env_map.var("SRC").unwrap(), "envfile")
-    assert_eq!(env_map.var("FOO").unwrap(), "bar")
+      .load()
+    assert_eq(env_map.get("SRC").unwrap(), "envfile")
+    assert_eq(env_map.get("FOO").unwrap(), "bar")
     let env_map = EnvLoader::from_string(s)
       .set_sequence(EnvSequence::InputThenEnv)
-      .load!()
-    assert_eq!(env_map.var("SRC").unwrap(), "env")
+      .load()
+    assert_eq(env_map.get("SRC").unwrap(), "env")
   })
 }
 
 ///|
 test "modify" {
   let s = "SRC=envfile\nFOO=bar"
-  temp_env!({ "SRC": "env" }, fn() -> Unit!Error {
+  temp_env({ "SRC": "env" }, fn() -> Unit raise Error {
     let loader = EnvLoader::from_string(s).set_sequence(
       EnvSequence::InputThenEnv,
     )
-    ignore(loader.load_and_modify!())
-    assert_eq!(@sys.get_env_vars()["SRC"].unwrap(), "env")
-    assert_eq!(@sys.get_env_vars()["FOO"].unwrap(), "bar")
+    ignore(loader.load_and_modify())
+    assert_eq(@sys.get_env_vars().get("SRC").unwrap(), "env")
+    assert_eq(@sys.get_env_vars().get("FOO").unwrap(), "bar")
   })
   // override
-  temp_env!({ "SRC": "env" }, fn() -> Unit!Error {
+  temp_env({ "SRC": "env" }, fn() -> Unit raise Error {
     let loader = EnvLoader::from_string(s).set_sequence(
       EnvSequence::EnvThenInput,
     )
-    ignore(loader.load_and_modify!())
-    assert_eq!(@sys.get_env_vars()["SRC"].unwrap(), "envfile")
-    assert_eq!(@sys.get_env_vars()["FOO"].unwrap(), "bar")
+    ignore(loader.load_and_modify())
+    assert_eq(@sys.get_env_vars().get("SRC").unwrap(), "envfile")
+    assert_eq(@sys.get_env_vars().get("FOO").unwrap(), "bar")
   })
 }

--- a/src/parse.mbt
+++ b/src/parse.mbt
@@ -1,10 +1,10 @@
 ///|
 fn parse_line(
   line : String,
-  substitution_data : @hashmap.T[String, String?]
-) -> (String, String)?!ParseBufError {
+  substitution_data : @hashmap.T[String, String?],
+) -> (String, String)? raise ParseBufError {
   let parser = LineParser::new(line, substitution_data)
-  parser.parse_line!()
+  parser.parse_line()
 }
 
 ///|
@@ -18,7 +18,7 @@ priv struct LineParser {
 ///|
 fn LineParser::new(
   line : String,
-  substitution_data : @hashmap.T[String, String?]
+  substitution_data : @hashmap.T[String, String?],
 ) -> LineParser {
   {
     original_line: line,
@@ -34,49 +34,51 @@ fn LineParser::err(self : LineParser) -> ParseBufError {
 }
 
 ///|
-fn LineParser::parse_line(self : LineParser) -> (String, String)?!ParseBufError {
+fn LineParser::parse_line(
+  self : LineParser,
+) -> (String, String)? raise ParseBufError {
   self.skip_whitespace()
   // if its an empty line or a comment, skip it
-  if self.line.is_empty() || self.line.starts_with("#") {
+  if self.line.is_empty() || self.line.strip_prefix("#") is Some(_) {
     return None
   }
-  let mut key = self.parse_key!()
+  let mut key = self.parse_key()
   self.skip_whitespace()
 
   // export can be either an optional prefix or a key itself
   if key == "export" {
     // here we check for an optional `=`, below we throw directly when it’s not found.
     if self.expect_equal().is_err() {
-      key = self.parse_key!()
+      key = self.parse_key()
       self.skip_whitespace()
-      self.expect_equal().unwrap_or_error!()
+      self.expect_equal().unwrap_or_error()
     }
   } else {
-    self.expect_equal().unwrap_or_error!()
+    self.expect_equal().unwrap_or_error()
   }
   self.skip_whitespace()
-  if self.line.is_empty() || self.line.starts_with("#") {
+  if self.line.is_empty() || self.line.strip_prefix("#") is Some(_) {
     self.substitution_data[key] = None
     return Some((key, ""))
   }
-  let parsed_value = parse_value!(self.line, self.substitution_data)
+  let parsed_value = parse_value(self.line, self.substitution_data)
   self.substitution_data[key] = Some(parsed_value)
   Some((key, parsed_value))
 }
 
 ///|
-fn LineParser::parse_key(self : LineParser) -> String!ParseBufError {
+fn LineParser::parse_key(self : LineParser) -> String raise ParseBufError {
   fn string_starts_with(src : String, predicate : (Char) -> Bool) -> Bool {
     if src.length() == 0 {
       return false
     }
-    predicate(src[0])
+    predicate(src.get_char(0).unwrap())
   }
 
   fn string_find(src : String, predicate : (Char) -> Bool) -> UInt? {
     let mut index = 0U
     while index < src.length().reinterpret_as_uint() {
-      if predicate(src[index.reinterpret_as_int()]) {
+      if predicate(src.get_char(index.reinterpret_as_int()).unwrap()) {
         return Some(index)
       }
       index += 1
@@ -106,7 +108,7 @@ fn LineParser::parse_key(self : LineParser) -> String!ParseBufError {
 
 ///|
 fn LineParser::expect_equal(self : LineParser) -> Result[Unit, ParseBufError] {
-  if not(self.line.starts_with("=")) {
+  if not(self.line.strip_prefix("=") is Some(_)) {
     return Err(self.err())
   }
   self.line = self.line.substring(start=1)
@@ -118,7 +120,7 @@ fn LineParser::expect_equal(self : LineParser) -> Result[Unit, ParseBufError] {
 fn LineParser::skip_whitespace(self : LineParser) -> Unit {
   let mut first_space = 0
   while first_space < self.line.length() {
-    if not(self.line[first_space].is_whitespace()) {
+    if not(self.line.get_char(first_space).unwrap().is_whitespace()) {
       break
     }
     first_space += 1
@@ -140,8 +142,8 @@ priv enum SubstitutionMode {
 ///|
 fn parse_value(
   input : String,
-  substitution_data : @hashmap.T[String, String?]
-) -> String!ParseBufError {
+  substitution_data : @hashmap.T[String, String?],
+) -> String raise ParseBufError {
   // '
   let mut strong_quote = false
   // "
@@ -275,13 +277,13 @@ fn parse_value(
 fn apply_substitution(
   substitution_data : @hashmap.T[String, String?],
   substitution_name : String,
-  output : StringBuilder
+  output : StringBuilder,
 ) -> Unit {
   let env_vars = @sys.get_env_vars()
   if env_vars.contains(substitution_name) {
-    output.write_string(env_vars[substitution_name].unwrap())
+    output.write_string(env_vars.get(substitution_name).unwrap())
   } else {
-    let stored_value = substitution_data[substitution_name].or(None)
-    output.write_string(stored_value.or_default())
+    let stored_value = substitution_data.get(substitution_name).unwrap_or(None)
+    output.write_string(stored_value.unwrap_or_default())
   }
 }

--- a/src/parse_error_wbtest.mbt
+++ b/src/parse_error_wbtest.mbt
@@ -4,9 +4,10 @@
 test "should not parse unfinished subs" {
   let invalid_value = ">${baz{<"
   let iter = DotenvIter::new(
-    #|FOO=bar
-    #|BAR={invalid_value}
-    .replace(old="{invalid_value}", new=invalid_value),
+    (
+      #|FOO=bar
+      #|BAR={invalid_value}
+    ).replace(old="{invalid_value}", new=invalid_value),
   )
   let parsed : Array[Result[(String, String), ParseBufError]] = Array::new()
   for {
@@ -17,7 +18,7 @@ test "should not parse unfinished subs" {
   }
 
   // first line works
-  assert_eq!(parsed[0].unwrap(), ("FOO", "bar"))
+  assert_eq(parsed[0].unwrap(), ("FOO", "bar"))
   // second line error
   match parsed[1] {
     Err(ParseBufError::LineParse(v, idx)) if v == invalid_value &&
@@ -73,7 +74,7 @@ test "should not parse invalid escape" {
   }
   match parsed[0] {
     Err(ParseBufError::LineParse(v, idx)) if v == invalid_esc &&
-      idx == (invalid_esc.index_of("\\") + 1).reinterpret_as_uint() => ()
+      idx == (invalid_esc.find("\\").unwrap() + 1).reinterpret_as_uint() => ()
     _ => abort("Expected error for invalid escape")
   }
 }

--- a/src/parse_substitution_wbtest.mbt
+++ b/src/parse_substitution_wbtest.mbt
@@ -102,7 +102,7 @@ test "recursive substitution" {
 }
 
 ///|
-test "var without paranthesis subbed before separators" {
+test "var without parenthesis subbed before separators" {
   assert_str(
     (
       #|KEY1=test_user

--- a/src/parse_substitution_wbtest.mbt
+++ b/src/parse_substitution_wbtest.mbt
@@ -1,106 +1,115 @@
 ///|
 fn assert_str(
   actual : String,
-  expected : Array[(String, String)]
-) -> Unit!Error {
+  expected : Array[(String, String)],
+) -> Unit raise Error {
   let actual_iter = DotenvIter::new(actual)
   let expected_count = expected.length()
   let mut count = 0
   for expected_item in expected {
-    let actual_item = actual_iter.next().unwrap().unwrap_or_error!()
-    assert_eq!(actual_item, expected_item)
+    let actual_item = actual_iter.next().unwrap().unwrap_or_error()
+    assert_eq(actual_item, expected_item)
     count += 1
   }
-  assert_eq!(count, expected_count)
+  assert_eq(count, expected_count)
 }
 
 ///|
 test "variable in parenthesis surrounded by quotes" {
-  assert_str!(
-    #|KEY=test
-    #|KEY1="${KEY}"
-    #|
-    ,
+  assert_str(
+    (
+      #|KEY=test
+      #|KEY1="${KEY}"
+      #|
+    ),
     [("KEY", "test"), ("KEY1", "test")],
   )
 }
 
 ///|
 test "sub undefined variables to empty string" {
-  assert_str!(
-    #|KEY=">$KEY1<>${KEY2}<"
-    ,
+  assert_str(
+    (
+      #|KEY=">$KEY1<>${KEY2}<"
+    ),
     [("KEY", "><><")],
   )
 }
 
 ///|
 test "do not sub with dollar escaped" {
-  assert_str!(
-    #|KEY=>\$KEY1<>\${KEY2}<
-    ,
+  assert_str(
+    (
+      #|KEY=>\$KEY1<>\${KEY2}<
+    ),
     [("KEY", ">$KEY1<>${KEY2}<")],
   )
 }
 
 ///|
 test "do not sub in weak quotes with dollar escaped" {
-  assert_str!(
-    #|KEY=">\$KEY1<>\${KEY2}<"
-    ,
+  assert_str(
+    (
+      #|KEY=">\$KEY1<>\${KEY2}<"
+    ),
     [("KEY", ">$KEY1<>${KEY2}<")],
   )
 }
 
 ///|
 test "do not sub in strong quotes" {
-  assert_str!(
-    #|KEY='>${KEY1}<>$KEY2<'
-    ,
+  assert_str(
+    (
+      #|KEY='>${KEY1}<>$KEY2<'
+    ),
     [("KEY", ">${KEY1}<>$KEY2<")],
   )
 }
 
 ///|
 test "same variable reused" {
-  assert_str!(
-    #|KEY=VALUE
-    #|KEY1=$KEY$KEY
-    #|
-    ,
+  assert_str(
+    (
+      #|KEY=VALUE
+      #|KEY1=$KEY$KEY
+      #|
+    ),
     [("KEY", "VALUE"), ("KEY1", "VALUEVALUE")],
   )
 }
 
 ///|
 test "with dot" {
-  assert_str!(
-    #|KEY.Value=VALUE
-    #|
-    ,
+  assert_str(
+    (
+      #|KEY.Value=VALUE
+      #|
+    ),
     [("KEY.Value", "VALUE")],
   )
 }
 
 ///|
 test "recursive substitution" {
-  assert_str!(
-    #|KEY=${KEY1}+KEY_VALUE
-    #|KEY1=${KEY}+KEY1_VALUE
-    #|
-    ,
+  assert_str(
+    (
+      #|KEY=${KEY1}+KEY_VALUE
+      #|KEY1=${KEY}+KEY1_VALUE
+      #|
+    ),
     [("KEY", "+KEY_VALUE"), ("KEY1", "+KEY_VALUE+KEY1_VALUE")],
   )
 }
 
 ///|
 test "var without paranthesis subbed before separators" {
-  assert_str!(
-    #|KEY1=test_user
-    #|KEY1_1=test_user_with_separator
-    #|KEY=">$KEY1_1<>$KEY1}<>$KEY1{<"
-    #|
-    ,
+  assert_str(
+    (
+      #|KEY1=test_user
+      #|KEY1_1=test_user_with_separator
+      #|KEY=">$KEY1_1<>$KEY1}<>$KEY1{<"
+      #|
+    ),
     [
       ("KEY1", "test_user"),
       ("KEY1_1", "test_user_with_separator"),
@@ -111,10 +120,11 @@ test "var without paranthesis subbed before separators" {
 
 ///|
 test "sub var from env var" {
-  temp_env!({ "KEY11": "test_user_env" }, fn() {
-    assert_str!(
-      #|KEY=">${KEY11}<"
-      ,
+  temp_env({ "KEY11": "test_user_env" }, fn() {
+    assert_str(
+      (
+        #|KEY=">${KEY11}<"
+      ),
       [("KEY", ">test_user_env<")],
     )
   })
@@ -122,12 +132,13 @@ test "sub var from env var" {
 
 ///|
 test "substitute variable env variable overrides dotenv in substitution" {
-  temp_env!({ "KEY11": "test_user_env" }, fn() {
-    assert_str!(
-      #|KEY11=test_user
-      #|KEY=">${KEY11}<"
-      #|
-      ,
+  temp_env({ "KEY11": "test_user_env" }, fn() {
+    assert_str(
+      (
+        #|KEY11=test_user
+        #|KEY=">${KEY11}<"
+        #|
+      ),
       [("KEY11", "test_user"), ("KEY", ">test_user_env<")],
     )
   })
@@ -135,12 +146,13 @@ test "substitute variable env variable overrides dotenv in substitution" {
 
 ///|
 test "consequent substitutions" {
-  assert_str!(
-    #|KEY1=test_user
-    #|KEY2=$KEY1_2
-    #|KEY=>${KEY1}<>${KEY2}<
-    #|
-    ,
+  assert_str(
+    (
+      #|KEY1=test_user
+      #|KEY2=$KEY1_2
+      #|KEY=>${KEY1}<>${KEY2}<
+      #|
+    ),
     [
       ("KEY1", "test_user"),
       ("KEY2", "test_user_2"),
@@ -151,11 +163,12 @@ test "consequent substitutions" {
 
 ///|
 test "consequent substitutions with one missing" {
-  assert_str!(
-    #|KEY2=$KEY1_2
-    #|KEY=>${KEY1}<>${KEY2}<
-    #|
-    ,
+  assert_str(
+    (
+      #|KEY2=$KEY1_2
+      #|KEY=>${KEY1}<>${KEY2}<
+      #|
+    ),
     [("KEY2", "_2"), ("KEY", "><>_2<")],
   )
 }

--- a/src/parse_wbtest.mbt
+++ b/src/parse_wbtest.mbt
@@ -2,20 +2,21 @@
 test "parse line env" {
   // Note 5 spaces after 'KEY8=' below
   let actual_iter = DotenvIter::new(
-    #|KEY=1
-    #|KEY2="2"
-    #|KEY3='3'
-    #|KEY4='fo ur'
-    #|KEY5="fi ve"
-    #|KEY6=s\ ix
-    #|KEY7=
-    #|KEY8=     
-    #|KEY9=   # foo
-    #|KEY10  ="whitespace before ="
-    #|KEY11=    "whitespace after ="
-    #|export="export as key"
-    #|export   SHELL_LOVER=1
-    ,
+    (
+      #|KEY=1
+      #|KEY2="2"
+      #|KEY3='3'
+      #|KEY4='fo ur'
+      #|KEY5="fi ve"
+      #|KEY6=s\ ix
+      #|KEY7=
+      #|KEY8=     
+      #|KEY9=   # foo
+      #|KEY10  ="whitespace before ="
+      #|KEY11=    "whitespace after ="
+      #|export="export as key"
+      #|export   SHELL_LOVER=1
+    ),
   )
   let expected_iter = [
     ("KEY", "1"),
@@ -35,11 +36,11 @@ test "parse line env" {
   let actual_parsed = []
   for {
     match actual_iter.next() {
-      Some(i) => actual_parsed.push(i.unwrap_or_error!())
+      Some(i) => actual_parsed.push(i.unwrap_or_error())
       None => break
     }
   }
-  assert_eq!(actual_parsed, expected_iter)
+  assert_eq(actual_parsed, expected_iter)
 }
 
 ///|
@@ -51,46 +52,48 @@ test "parse line comment" {
   let parsed = []
   for {
     match result.next() {
-      Some(i) => parsed.push(i.unwrap_or_error!())
+      Some(i) => parsed.push(i.unwrap_or_error())
       None => break
     }
   }
-  assert_eq!(parsed, [])
+  assert_eq(parsed, [])
 }
 
 ///|
 test "parse line invalid" {
   // Note 4 spaces after 'invalid' below
   let actual_iter = DotenvIter::new(
-    #|  invalid    
-    #|very bacon = yes indeed
-    #|=value
-    ,
+    (
+      #|  invalid    
+      #|very bacon = yes indeed
+      #|=value
+    ),
   )
   let mut count = 0
   for {
     match actual_iter.next() {
       Some(i) => {
         count += 1
-        assert_true!(i.is_err())
+        assert_true(i.is_err())
       }
       None => break
     }
   }
-  assert_eq!(count, 3)
+  assert_eq(count, 3)
 }
 
 ///|
 test "parse value escapes" {
   let actual_iter = DotenvIter::new(
-    #|KEY=my\ cool\ value
-    #|KEY2=\$sweet
-    #|KEY3="awesome stuff \"mang\""
-    #|KEY4='sweet $\fgs'\''fds'
-    #|KEY5="'\"yay\\"\ "stuff"
-    #|KEY6="lol" #well you see when I say lol wh
-    #|KEY7="line 1\nline 2"
-    ,
+    (
+      #|KEY=my\ cool\ value
+      #|KEY2=\$sweet
+      #|KEY3="awesome stuff \"mang\""
+      #|KEY4='sweet $\fgs'\''fds'
+      #|KEY5="'\"yay\\"\ "stuff"
+      #|KEY6="lol" #well you see when I say lol wh
+      #|KEY7="line 1\nline 2"
+    ),
   )
   let expected = [
     ("KEY", "my cool value"),
@@ -104,26 +107,27 @@ test "parse value escapes" {
   let actual_parsed = []
   for {
     match actual_iter.next() {
-      Some(i) => actual_parsed.push(i.unwrap_or_error!())
+      Some(i) => actual_parsed.push(i.unwrap_or_error())
       None => break
     }
   }
-  assert_eq!(actual_parsed, expected)
+  assert_eq(actual_parsed, expected)
 }
 
 ///|
 test "parse value escapes invalid" {
   let actual_iter = DotenvIter::new(
-    #|KEY=my uncool value
-    #|KEY2="why
-    #|KEY3='please stop''
-    #|KEY4=h\8u
-    #|
-    ,
+    (
+      #|KEY=my uncool value
+      #|KEY2="why
+      #|KEY3='please stop''
+      #|KEY4=h\8u
+      #|
+    ),
   )
   for {
     match actual_iter.next() {
-      Some(i) => assert_true!(i.is_err())
+      Some(i) => assert_true(i.is_err())
       None => break
     }
   }

--- a/src/temp_env.mbt
+++ b/src/temp_env.mbt
@@ -1,17 +1,25 @@
 ///| This function is for testing only.
 /// Do not use this in production code.
 /// It is not thread-safe.
-pub fn temp_env[R, E : Error](
+pub fn[R, E : Error] temp_env(
   temp_envs : Map[String, String],
-  f : () -> R!E
-) -> R!E {
+  f : () -> R raise E,
+) -> R raise E {
   let original_vars = @sys.get_env_vars()
   for key, value in temp_envs {
     @sys.set_env_var(key, value)
   }
-  let result = f?()
+  let result = f() catch {
+    e => {
+      // Restore environment before re-raising
+      for key, value in original_vars {
+        @sys.set_env_var(key, value)
+      }
+      raise e
+    }
+  }
   for key, value in original_vars {
     @sys.set_env_var(key, value)
   }
-  result.unwrap_or_error!()
+  result
 }


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

This PR fixes all compiler warnings by migrating all deprecated APIs.

Updating `moonbitlang/x` manually beforehand turns out to be required for the fix to work.

## Breaking Changes

- `EnvMap::var()` was renamed to `EnvMap::get()` due to `var` being listed in the reserved words.