### PR TITLE
Fix string indexing type warnings for moon check compatibility

### DIFF
--- a/src/cursor.mbt
+++ b/src/cursor.mbt
@@ -21,14 +21,14 @@ fn Cursor::read_line(self : Cursor) -> String {
       result.write_char('\n')
       break
     }
-    if byte == '\n'.to_int() {
+    if byte == 0x0a {
       result.write_char('\n')
       break
     }
-    if byte == '\r'.to_int() {
+    if byte == 0x0d {
       // Check if the next byte is a newline(CRLF)
       let next = self.peek()
-      if next == Some('\n') {
+      if next == Some(0x0a) {
         // Skip the newline byte
         ignore(self.next())
       }
@@ -47,22 +47,22 @@ fn Cursor::length(self : Cursor) -> UInt64 {
 }
 
 ///|
-fn Cursor::next(self : Cursor) -> Int? {
+fn Cursor::next(self : Cursor) -> UInt16? {
   if self.pos >= self.data.length().to_uint64() {
     None
   } else {
-    let char = self.data[self.pos.to_int()]
+    let char = self.data.code_unit_at(self.pos.to_int())
     self.pos += 1
     Some(char)
   }
 }
 
 ///|
-fn Cursor::peek(self : Cursor) -> Int? {
+fn Cursor::peek(self : Cursor) -> UInt16? {
   if self.pos >= self.data.length().to_uint64() {
     None
   } else {
-    Some(self.data[self.pos.to_int()])
+    Some(self.data.code_unit_at(self.pos.to_int()))
   }
 }
 

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -2,11 +2,11 @@
 package "ShellWen/dotenv"
 
 // Values
-fn load(path? : String, ignore_file_not_found? : Bool) -> EnvMap raise DotenvError
+pub fn load(path? : String, ignore_file_not_found? : Bool) -> EnvMap raise DotenvError
 
-fn load_and_modify(path? : String, ignore_file_not_found? : Bool) -> EnvMap raise DotenvError
+pub fn load_and_modify(path? : String, ignore_file_not_found? : Bool) -> EnvMap raise DotenvError
 
-fn[R, E : Error] temp_env(Map[String, String], () -> R raise E) -> R raise E
+pub fn[R, E : Error] temp_env(Map[String, String], () -> R raise E) -> R raise E
 
 // Errors
 pub suberror DotenvError {
@@ -25,15 +25,15 @@ pub struct EnvLoader {
   mut path : String?
   // private fields
 }
-fn EnvLoader::from_path(String) -> Self raise DotenvError
-fn EnvLoader::from_string(String) -> Self
-fn EnvLoader::load(Self) -> EnvMap raise DotenvError
-fn EnvLoader::load_and_modify(Self) -> EnvMap raise DotenvError
-fn EnvLoader::set_path(Self, String?) -> Self
-fn EnvLoader::set_sequence(Self, EnvSequence) -> Self
+pub fn EnvLoader::from_path(String) -> Self raise DotenvError
+pub fn EnvLoader::from_string(String) -> Self
+pub fn EnvLoader::load(Self) -> EnvMap raise DotenvError
+pub fn EnvLoader::load_and_modify(Self) -> EnvMap raise DotenvError
+pub fn EnvLoader::set_path(Self, String?) -> Self
+pub fn EnvLoader::set_sequence(Self, EnvSequence) -> Self
 
 type EnvMap
-fn EnvMap::get(Self, String) -> String?
+pub fn EnvMap::get(Self, String) -> String?
 
 pub(all) enum EnvSequence {
   EnvOnly
@@ -41,7 +41,7 @@ pub(all) enum EnvSequence {
   InputOnly
   InputThenEnv
 }
-impl Default for EnvSequence
+pub impl Default for EnvSequence
 
 // Type aliases
 


### PR DESCRIPTION
## Summary

Fixed type warnings related to string indexing operations to ensure `moon check` passes without warnings. The main issue was that `string[i]` now returns `UInt16` instead of `Int`, requiring proper type conversion.

## Changes

- **src/cursor.mbt**: Updated string indexing operations to use correct `UInt16` type conversion
- **src/pkg.generated.mbti**: Regenerated type information to reflect the updated signatures

## Implementation Details

The changes focus on minimal modifications to address the type system update where string indexing now returns `UInt16` instead of `Int`. This ensures compatibility with the current MoonBit type checker while maintaining existing functionality.

## Verification

- `moon check` now runs without warnings
- Maintains backward compatibility with existing functionality
- Minimal code changes to reduce risk of introducing new issues